### PR TITLE
Add Azure OpenAI embedding support

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2124,6 +2124,27 @@ RAG_OPENAI_API_KEY = PersistentConfig(
     os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY),
 )
 
+RAG_AZURE_OPENAI_BASE_URL = PersistentConfig(
+    "RAG_AZURE_OPENAI_BASE_URL",
+    "rag.azure_openai.base_url",
+    os.getenv("RAG_AZURE_OPENAI_BASE_URL", ""),
+)
+RAG_AZURE_OPENAI_API_KEY = PersistentConfig(
+    "RAG_AZURE_OPENAI_API_KEY",
+    "rag.azure_openai.api_key",
+    os.getenv("RAG_AZURE_OPENAI_API_KEY", ""),
+)
+RAG_AZURE_OPENAI_DEPLOYMENT = PersistentConfig(
+    "RAG_AZURE_OPENAI_DEPLOYMENT",
+    "rag.azure_openai.deployment",
+    os.getenv("RAG_AZURE_OPENAI_DEPLOYMENT", ""),
+)
+RAG_AZURE_OPENAI_VERSION = PersistentConfig(
+    "RAG_AZURE_OPENAI_VERSION",
+    "rag.azure_openai.version",
+    os.getenv("RAG_AZURE_OPENAI_VERSION", ""),
+)
+
 RAG_OLLAMA_BASE_URL = PersistentConfig(
     "RAG_OLLAMA_BASE_URL",
     "rag.ollama.url",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -202,6 +202,10 @@ from open_webui.config import (
     RAG_FILE_MAX_SIZE,
     RAG_OPENAI_API_BASE_URL,
     RAG_OPENAI_API_KEY,
+    RAG_AZURE_OPENAI_BASE_URL,
+    RAG_AZURE_OPENAI_API_KEY,
+    RAG_AZURE_OPENAI_DEPLOYMENT,
+    RAG_AZURE_OPENAI_VERSION,
     RAG_OLLAMA_BASE_URL,
     RAG_OLLAMA_API_KEY,
     CHUNK_OVERLAP,
@@ -688,6 +692,11 @@ app.state.config.RAG_TEMPLATE = RAG_TEMPLATE
 app.state.config.RAG_OPENAI_API_BASE_URL = RAG_OPENAI_API_BASE_URL
 app.state.config.RAG_OPENAI_API_KEY = RAG_OPENAI_API_KEY
 
+app.state.config.RAG_AZURE_OPENAI_BASE_URL = RAG_AZURE_OPENAI_BASE_URL
+app.state.config.RAG_AZURE_OPENAI_API_KEY = RAG_AZURE_OPENAI_API_KEY
+app.state.config.RAG_AZURE_OPENAI_DEPLOYMENT = RAG_AZURE_OPENAI_DEPLOYMENT
+app.state.config.RAG_AZURE_OPENAI_VERSION = RAG_AZURE_OPENAI_VERSION
+
 app.state.config.RAG_OLLAMA_BASE_URL = RAG_OLLAMA_BASE_URL
 app.state.config.RAG_OLLAMA_API_KEY = RAG_OLLAMA_API_KEY
 
@@ -781,14 +790,32 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
     (
         app.state.config.RAG_OPENAI_API_BASE_URL
         if app.state.config.RAG_EMBEDDING_ENGINE == "openai"
-        else app.state.config.RAG_OLLAMA_BASE_URL
+        else (
+            app.state.config.RAG_OLLAMA_BASE_URL
+            if app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
+            else app.state.config.RAG_AZURE_OPENAI_BASE_URL
+        )
     ),
     (
         app.state.config.RAG_OPENAI_API_KEY
         if app.state.config.RAG_EMBEDDING_ENGINE == "openai"
-        else app.state.config.RAG_OLLAMA_API_KEY
+        else (
+            app.state.config.RAG_OLLAMA_API_KEY
+            if app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
+            else app.state.config.RAG_AZURE_OPENAI_API_KEY
+        )
     ),
     app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+    (
+        app.state.config.RAG_AZURE_OPENAI_DEPLOYMENT
+        if app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
+        else None
+    ),
+    (
+        app.state.config.RAG_AZURE_OPENAI_VERSION
+        if app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
+        else None
+    ),
 )
 
 ########################################

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -180,15 +180,23 @@ export const getEmbeddingConfig = async (token: string) => {
 };
 
 type OpenAIConfigForm = {
-	key: string;
-	url: string;
+        key: string;
+        url: string;
+};
+
+type AzureOpenAIConfigForm = {
+        key: string;
+        url: string;
+        deployment: string;
+        version: string;
 };
 
 type EmbeddingModelUpdateForm = {
-	openai_config?: OpenAIConfigForm;
-	embedding_engine: string;
-	embedding_model: string;
-	embedding_batch_size?: number;
+        openai_config?: OpenAIConfigForm;
+        azure_openai_config?: AzureOpenAIConfigForm;
+        embedding_engine: string;
+        embedding_model: string;
+        embedding_batch_size?: number;
 };
 
 export const updateEmbeddingConfig = async (token: string, payload: EmbeddingModelUpdateForm) => {

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -43,8 +43,13 @@
 	let embeddingBatchSize = 1;
 	let rerankingModel = '';
 
-	let OpenAIUrl = '';
-	let OpenAIKey = '';
+        let OpenAIUrl = '';
+        let OpenAIKey = '';
+
+        let AzureOpenAIUrl = '';
+        let AzureOpenAIKey = '';
+        let AzureOpenAIDeployment = '';
+        let AzureOpenAIVersion = '';
 
 	let OllamaUrl = '';
 	let OllamaKey = '';
@@ -86,27 +91,40 @@
 			return;
 		}
 
-		if ((embeddingEngine === 'openai' && OpenAIKey === '') || OpenAIUrl === '') {
-			toast.error($i18n.t('OpenAI URL/Key required.'));
-			return;
-		}
+                if (embeddingEngine === 'openai' && (OpenAIKey === '' || OpenAIUrl === '')) {
+                        toast.error($i18n.t('OpenAI URL/Key required.'));
+                        return;
+                }
+                if (
+                        embeddingEngine === 'azure_openai' &&
+                        (AzureOpenAIKey === '' || AzureOpenAIUrl === '' || AzureOpenAIDeployment === '' || AzureOpenAIVersion === '')
+                ) {
+                        toast.error($i18n.t('OpenAI URL/Key required.'));
+                        return;
+                }
 
 		console.debug('Update embedding model attempt:', embeddingModel);
 
 		updateEmbeddingModelLoading = true;
-		const res = await updateEmbeddingConfig(localStorage.token, {
-			embedding_engine: embeddingEngine,
-			embedding_model: embeddingModel,
-			embedding_batch_size: embeddingBatchSize,
-			ollama_config: {
-				key: OllamaKey,
-				url: OllamaUrl
-			},
-			openai_config: {
-				key: OpenAIKey,
-				url: OpenAIUrl
-			}
-		}).catch(async (error) => {
+                const res = await updateEmbeddingConfig(localStorage.token, {
+                        embedding_engine: embeddingEngine,
+                        embedding_model: embeddingModel,
+                        embedding_batch_size: embeddingBatchSize,
+                        ollama_config: {
+                                key: OllamaKey,
+                                url: OllamaUrl
+                        },
+                        openai_config: {
+                                key: OpenAIKey,
+                                url: OpenAIUrl
+                        },
+                        azure_openai_config: {
+                                key: AzureOpenAIKey,
+                                url: AzureOpenAIUrl,
+                                deployment: AzureOpenAIDeployment,
+                                version: AzureOpenAIVersion
+                        }
+                }).catch(async (error) => {
 			toast.error(`${error}`);
 			await setEmbeddingConfig();
 			return null;
@@ -186,13 +204,18 @@
 			embeddingModel = embeddingConfig.embedding_model;
 			embeddingBatchSize = embeddingConfig.embedding_batch_size ?? 1;
 
-			OpenAIKey = embeddingConfig.openai_config.key;
-			OpenAIUrl = embeddingConfig.openai_config.url;
+                        OpenAIKey = embeddingConfig.openai_config.key;
+                        OpenAIUrl = embeddingConfig.openai_config.url;
 
-			OllamaKey = embeddingConfig.ollama_config.key;
-			OllamaUrl = embeddingConfig.ollama_config.url;
-		}
-	};
+                        OllamaKey = embeddingConfig.ollama_config.key;
+                        OllamaUrl = embeddingConfig.ollama_config.url;
+
+                        AzureOpenAIKey = embeddingConfig.azure_openai_config.key;
+                        AzureOpenAIUrl = embeddingConfig.azure_openai_config.url;
+                        AzureOpenAIDeployment = embeddingConfig.azure_openai_config.deployment;
+                        AzureOpenAIVersion = embeddingConfig.azure_openai_config.version;
+                }
+        };
 	onMount(async () => {
 		await setEmbeddingConfig();
 
@@ -457,23 +480,26 @@
 										bind:value={embeddingEngine}
 										placeholder="Select an embedding model engine"
 										on:change={(e) => {
-											if (e.target.value === 'ollama') {
-												embeddingModel = '';
-											} else if (e.target.value === 'openai') {
-												embeddingModel = 'text-embedding-3-small';
-											} else if (e.target.value === '') {
-												embeddingModel = 'sentence-transformers/all-MiniLM-L6-v2';
-											}
+                                                                        if (e.target.value === 'ollama') {
+                                                                               embeddingModel = '';
+                                                                       } else if (e.target.value === 'openai') {
+                                                                               embeddingModel = 'text-embedding-3-small';
+                                                                       } else if (e.target.value === 'azure_openai') {
+                                                                               embeddingModel = 'text-embedding-3-small';
+                                                                       } else if (e.target.value === '') {
+                                                                               embeddingModel = 'sentence-transformers/all-MiniLM-L6-v2';
+                                                                       }
 										}}
 									>
 										<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
 										<option value="ollama">{$i18n.t('Ollama')}</option>
-										<option value="openai">{$i18n.t('OpenAI')}</option>
+                                                                               <option value="openai">{$i18n.t('OpenAI')}</option>
+                                                                               <option value="azure_openai">Azure OpenAI</option>
 									</select>
 								</div>
 							</div>
 
-							{#if embeddingEngine === 'openai'}
+                                                        {#if embeddingEngine === 'openai'}
 								<div class="my-0.5 flex gap-2 pr-2">
 									<input
 										class="flex-1 w-full text-sm bg-transparent outline-hidden"
@@ -484,7 +510,7 @@
 
 									<SensitiveInput placeholder={$i18n.t('API Key')} bind:value={OpenAIKey} />
 								</div>
-							{:else if embeddingEngine === 'ollama'}
+                                                        {:else if embeddingEngine === 'ollama'}
 								<div class="my-0.5 flex gap-2 pr-2">
 									<input
 										class="flex-1 w-full text-sm bg-transparent outline-hidden"
@@ -499,13 +525,40 @@
 										required={false}
 									/>
 								</div>
-							{/if}
-						</div>
+                                                        {:else if embeddingEngine === 'azure_openai'}
+                                                                <div class="my-0.5 flex flex-col gap-2 pr-2 w-full">
+                                                                        <div class="flex gap-2">
+                                                                                <input
+                                                                                        class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                        placeholder={$i18n.t('API Base URL')}
+                                                                                        bind:value={AzureOpenAIUrl}
+                                                                                        required
+                                                                                />
+                                                                                <SensitiveInput placeholder={$i18n.t('API Key')} bind:value={AzureOpenAIKey} />
+                                                                        </div>
+                                                                        <div class="flex gap-2">
+                                                                                <input
+                                                                                        class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                        placeholder="Deployment"
+                                                                                        bind:value={AzureOpenAIDeployment}
+                                                                                        required
+                                                                                />
+                                                                                <input
+                                                                                        class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                        placeholder="Version"
+                                                                                        bind:value={AzureOpenAIVersion}
+                                                                                        required
+                                                                                />
+                                                                        </div>
+                                                                </div>
+                                                        {/if}
+                                                </div>
 
-						<div class="  mb-2.5 flex flex-col w-full">
-							<div class=" mb-1 text-xs font-medium">{$i18n.t('Embedding Model')}</div>
+                                                {#if embeddingEngine !== 'azure_openai'}
+                                                        <div class="  mb-2.5 flex flex-col w-full">
+                                                                <div class=" mb-1 text-xs font-medium">{$i18n.t('Embedding Model')}</div>
 
-							<div class="">
+                                                                <div class="">
 								{#if embeddingEngine === 'ollama'}
 									<div class="flex w-full">
 										<div class="flex-1 mr-2">
@@ -592,10 +645,11 @@
 								{$i18n.t(
 									'Warning: If you update or change your embedding model, you will need to re-import all documents.'
 								)}
-							</div>
-						</div>
+                                                        </div>
+                                                </div>
+                                                {/if}
 
-						{#if embeddingEngine === 'ollama' || embeddingEngine === 'openai'}
+                                                {#if embeddingEngine === 'ollama' || embeddingEngine === 'openai' || embeddingEngine === 'azure_openai'}
 							<div class="  mb-2.5 flex w-full justify-between">
 								<div class=" self-center text-xs font-medium">
 									{$i18n.t('Embedding Batch Size')}


### PR DESCRIPTION
## Summary
- support Azure OpenAI embeddings in backend and frontend
- add Azure OpenAI settings and configuration handling
- extend embedding engines with `azure_openai`
- show Azure OpenAI fields in document settings
- hide embedding model field for Azure OpenAI option

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest -q` *(fails: ModuleNotFoundError: test.util)*